### PR TITLE
Add rocm-smi/check for Archlinux

### DIFF
--- a/archlinux/rocm-smi/Dockerfile
+++ b/archlinux/rocm-smi/Dockerfile
@@ -1,0 +1,36 @@
+FROM archlinux:latest
+
+RUN pacman -Syu --noconfirm \
+    base-devel \
+    git \
+    cmake \
+    python \
+    libdrm \
+    pciutils \
+    libpciaccess
+
+# Symlink headers so the build finds drm.h without issue
+RUN ln -s /usr/include/libdrm/* /usr/include/
+
+WORKDIR /opt
+RUN git clone https://github.com/ROCm/amdsmi.git
+
+WORKDIR /opt/amdsmi
+
+# Apply patch: Redefinition Error
+# Renaming the struct in local AMDSMI header to force compiler to use libdrm's official definition
+RUN sed -i 's/struct drm_color_ctm_3x4/struct drm_color_ctm_3x4_IGNORE/' include/amd_smi/impl/amdgpu_drm.h
+
+# Append the "Ignore Warnings" flags to the end of the config file.
+RUN echo 'add_compile_options(-w -fpermissive -Wno-error)' >> CMakeLists.txt
+
+# Build
+RUN mkdir build && cd build && \
+    cmake \
+    -DBUILD_TESTS=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    .. && \
+    make
+
+# Run the amdsmi test
+CMD ["/opt/amdsmi/build/tests/amd_smi_test/amdsmitst"]


### PR DESCRIPTION
Adding rocm-smi/check for Archlinux in similar format to Fedora Rawhide rocm-smi/check.

Added patches in Dockerfile equivalent to upstream patches for rocm-smi on FedoraProject to get Dockerfile to build.

Change-Id: I42f79d3a9c2e4e1f0a8f7289b2b98dad758f0f2f